### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/3rd-party-services/avatar-service/pom.xml
+++ b/3rd-party-services/avatar-service/pom.xml
@@ -13,13 +13,13 @@
         <repository>
             <id>maven.aksw.snapshot</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/archiva/repository/snapshots</url>
+            <url>https://maven.aksw.org/archiva/repository/snapshots</url>
         </repository>
 
         <repository>
             <id>maven.aksw.internal</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/archiva/repository/internal</url>
+            <url>https://maven.aksw.org/archiva/repository/internal</url>
         </repository>
     </repositories>
 

--- a/3rd-party-services/similarity-service/pom.xml
+++ b/3rd-party-services/similarity-service/pom.xml
@@ -17,12 +17,12 @@
         <repository>
             <id>maven.aksw.internal</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/repository/internal</url>
+            <url>https://maven.aksw.org/repository/internal</url>
         </repository>
         <repository>
             <id>maven.aksw.snapshots</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/repository/snapshots</url>
+            <url>https://maven.aksw.org/repository/snapshots</url>
         </repository>
         <repository>
             <id>Apache Repo</id>


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.